### PR TITLE
feat(ci): update GitHub Actions workflow for Karate tests

### DIFF
--- a/.github/workflows/karate-tests.yml
+++ b/.github/workflows/karate-tests.yml
@@ -7,20 +7,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
 
       - name: Run Karate Tests
-        run: mvn test
+        run: mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
       - name: Upload Karate Reports
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: karate-reports
           path: target/karate-reports


### PR DESCRIPTION
Update the GitHub Actions workflow for running Karate tests:
- Upgrade actions/checkout to v3
- Upgrade actions/setup-java to v3 and use Temurin distribution
- Add caching for Maven packages
- Add option to suppress verbose logging from Maven CLI transfer listener
- Upgrade actions/upload-artifact to v3

These changes improve the workflow's performance and reliability.