### PR TITLE
feat: Expand Karate test reporting in GitHub Actions

### DIFF
--- a/.github/workflows/karate-tests.yml
+++ b/.github/workflows/karate-tests.yml
@@ -26,9 +26,23 @@ jobs:
       - name: Run Karate Tests
         run: mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
+      - name: List directories
+        if: always()
+        run: |
+          echo "Current directory:"
+          ls -R
+          echo "Target directory:"
+          ls -R target || echo "Target directory not found"
+          echo "Karate reports directory:"
+          ls -R karate-reports || echo "Karate reports directory not found"
+
       - name: Upload Karate Reports
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: karate-reports
-          path: target/karate-reports
+          path: |
+            target/karate-reports
+            target/surefire-reports
+            karate-reports
+          if-no-files-found: warn


### PR DESCRIPTION
This commit enhances the Karate test reporting in the GitHub Actions
workflow by adding more detailed logging and expanding the artifact
upload to include additional report directories.

The key changes are:

- Add a "List directories" step to log the contents of the current
  directory, the "target" directory, and the "karate-reports" directory
  for debugging purposes.
- Update the "Upload Karate Reports" step to include the "target/
  surefire-reports" and "karate-reports" directories, in addition to
  the existing "target/karate-reports" directory.
- Set the "if-no-files-found" option to "warn" to avoid workflow
  failures if the additional report directories are not present.

These changes will provide more comprehensive test reporting in the
GitHub Actions workflow, making it easier to debug any issues that may
arise during the Karate tests.