### PR TITLE
feat(ci): Upgrade Java version to 17

### DIFF
--- a/.github/workflows/karate-tests.yml
+++ b/.github/workflows/karate-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
 


### PR DESCRIPTION
Updates the Java version used in the GitHub Actions
workflow from 11 to 17. This is done to ensure the
project is using the latest stable version of Java
and to take advantage of any performance improvements
or bug fixes that may have been introduced in the new
version.