### PR TITLE
feat: Add .history to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ karate-reports/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+.history


### PR DESCRIPTION
Adds the .history directory to the .gitignore file. This
is to exclude any IDE-specific history files from being
tracked in the repository.